### PR TITLE
Fix `loadPalette` crash if no palette saved before

### DIFF
--- a/chromata.sketchplugin/Contents/Sketch/Core/CHRPalette.js
+++ b/chromata.sketchplugin/Contents/Sketch/Core/CHRPalette.js
@@ -52,6 +52,7 @@ CHRPalette.savePalette = function(palette) {
  */
 CHRPalette.loadPalette = function() {
     let rawPaletteRgba = CHRUserDefaults.fetchValueForKey(kUserDefaultsPaletteKey)
+    if (!rawPaletteRgba) { return [] }
 
     let palette = []
     for (let i = 0; i < rawPaletteRgba.length; i++) {


### PR DESCRIPTION
Fixes #44 